### PR TITLE
Fix faulty props

### DIFF
--- a/src/components/WrldMap.tsx
+++ b/src/components/WrldMap.tsx
@@ -88,9 +88,9 @@ const WrldMap: React.FC<WrldMapProps> = ({
   );
 };
 
-const defaultProps = {
+const defaultProps: Partial<WrldMapProps> = {
   containerId: defaultContainerId,
-  constianerStyle: {
+  containerStyle: {
     width: "600px",
     height: "400px"
   },


### PR DESCRIPTION
The `withDefaultProps` higher order component is trying to do something clever with the types, but defaultProps had `{}` as a type for map options, instead of Wrld.MapOptions, causing the exported component to take a generic object as the option, rather than the proper type.

Correctly typing defaultProps as a partial version of WrldMapProps guarantees that all its field have the correct types, also highlighting an awkward typo.